### PR TITLE
Revert "Pin Pylibcugraphops to 22.10"

### DIFF
--- a/cugraph_nightly_torch.Dockerfile
+++ b/cugraph_nightly_torch.Dockerfile
@@ -18,7 +18,7 @@ RUN gpuci_mamba_retry install -y -c pytorch -c rapidsai-nightly -c rapidsai -c n
     cugraph=$RAPIDS_VER \
     dask-cudf=$RAPIDS_VER \
     dask-cuda=$RAPIDS_VER \
-    pylibcugraphops=22.10 \
+    pylibcugraphops=$RAPIDS_VER \
     pytorch=$PYTORCH_VER \
     python=$PYTHON_VER \
     setuptools \


### PR DESCRIPTION
Reverts rapidsai/dgl-cugraph-build-environment#2

Because of build issues: 

```

Encountered problems while solving:
  - package cugraph-22.12.00a221014-cuda11_py38_g4278e5c7_51 requires python >=3.8,<3.9.0a0, but none of the providers can be installed

    [gpuci_mamba_retry] Failed, mamba returned exit code: 1
    [gpuci_mamba_retry] Exiting, no retryable mamba errors detected: 'ChecksumMismatchError:' or 'CondaHTTPError:' or 'JSONDecodeError:' or 'EOFError:' or 'Multi-download failed'
    [gpuci_mamba_retry] 
```