### PR TITLE
Use ARC V2 self-hosted runners for CPU jobs

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   docker:
-    runs-on: [self-hosted, linux, amd64, cpu16]
+    runs-on: linux-amd64-cpu16
     env:
       DOCKERHUB_USERNAME: '${{ secrets.GPUCIBOT_DOCKERHUB_USER }}'
       DOCKERHUB_TOKEN: '${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}'


### PR DESCRIPTION
This PR is updating the runner labels to use ARC V2 self-hosted runners for CPU jobs only. This is needed to resolve the auto-scalling issues.